### PR TITLE
Persist fallback card names and update instance title

### DIFF
--- a/lib/features/cards/presentation/pages/card_list_page.dart
+++ b/lib/features/cards/presentation/pages/card_list_page.dart
@@ -99,6 +99,12 @@ class CardListPage extends StatelessWidget {
           nameJa: representative.card.nameJa,
         );
 
+        final displayTitle = _LocalizedCardTitle.computeDisplay(
+          fallback: representative.card.name,
+          nameEn: representative.card.nameEn,
+          nameJa: representative.card.nameJa,
+        );
+
         return CardListItem(
           card: representative,
           title: titleWidget,
@@ -110,7 +116,7 @@ class CardListPage extends StatelessWidget {
                 builder: (_) => BlocProvider.value(
                   value: context.read<CardBloc>(),
                   child: CardInstancesPage(
-                    title: representative.card.name,
+                    title: displayTitle,
                     instances: group,
                   ),
                 ),
@@ -151,8 +157,11 @@ class _LocalizedCardTitle extends StatelessWidget {
     this.nameJa,
   });
 
-  @override
-  Widget build(BuildContext context) {
+  static String computeDisplay({
+    required String fallback,
+    String? nameEn,
+    String? nameJa,
+  }) {
     // Prefer DB stored names if available; no network fetch here.
     final en = nameEn?.trim();
     final ja = nameJa?.trim();
@@ -168,6 +177,16 @@ class _LocalizedCardTitle extends StatelessWidget {
         display = en!;
       }
     }
+    return display;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final display = computeDisplay(
+      fallback: fallback,
+      nameEn: nameEn,
+      nameJa: nameJa,
+    );
     return Text(
       display,
       overflow: TextOverflow.ellipsis,

--- a/lib/features/cards/presentation/widgets/add_card_dialog.dart
+++ b/lib/features/cards/presentation/widgets/add_card_dialog.dart
@@ -117,8 +117,16 @@ class _AddCardDialogState extends State<AddCardDialog> {
         final n = c.collectorNumberInt;
         cardNumberController.text = n != null ? '$n' : '';
         _selectedOracleId = c.oracleId;
-        _selectedNameEn = c.name.isNotEmpty ? c.name : null;
-        _selectedNameJa = (c.printedName != null && c.printedName!.isNotEmpty) ? c.printedName : null;
+        final printed = c.printedName;
+        final hasPrinted = printed != null && printed.isNotEmpty;
+        String? fallbackName;
+        if (hasPrinted) {
+          fallbackName = printed;
+        } else if (c.name.isNotEmpty) {
+          fallbackName = c.name;
+        }
+        _selectedNameEn = fallbackName;
+        _selectedNameJa = hasPrinted ? printed : fallbackName;
       });
     } catch (_) {
       // UI上では失敗を通知せずに無視する
@@ -177,6 +185,16 @@ class _AddCardDialogState extends State<AddCardDialog> {
           final n = selected.collectorNumberInt;
           cardNumberController.text = n != null ? '$n' : '';
           _selectedOracleId = selected.oracleId;
+          final printed = selected.printedName;
+          final hasPrinted = printed != null && printed.isNotEmpty;
+          String? fallbackName;
+          if (hasPrinted) {
+            fallbackName = printed;
+          } else if (selected.name.isNotEmpty) {
+            fallbackName = selected.name;
+          }
+          _selectedNameEn = fallbackName;
+          _selectedNameJa = hasPrinted ? printed : fallbackName;
         });
       }
     } catch (_) {
@@ -374,8 +392,16 @@ class _AddCardDialogState extends State<AddCardDialog> {
                           final c = await _scryfall.getCardByExactName(name);
                           if (c != null) {
                             oracleId = c.oracleId;
-                            nameEn ??= c.name.isNotEmpty ? c.name : null;
-                            nameJa ??= (c.printedName != null && c.printedName!.isNotEmpty) ? c.printedName : null;
+                            final printed = c.printedName;
+                            final hasPrinted = printed != null && printed.isNotEmpty;
+                            String? fallbackName;
+                            if (hasPrinted) {
+                              fallbackName = printed;
+                            } else if (c.name.isNotEmpty) {
+                              fallbackName = c.name;
+                            }
+                            nameEn ??= fallbackName;
+                            nameJa ??= hasPrinted ? printed : fallbackName;
                           }
                         }
                         if (!dialogContext.mounted) return;


### PR DESCRIPTION
## Summary
- apply the printed-name/English fallback when storing selected card names from Scryfall so null values are avoided
- reuse the same fallback when lazily fetching card info before dispatching the add event
- show grouped card instance pages with the localized display title to match the list view

## Testing
- flutter analyze *(fails: flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb523e096c83299dcf70f62aab1a83