### PR TITLE
Improve container edit flow on card instances page

### DIFF
--- a/lib/features/cards/presentation/pages/card_instances_page.dart
+++ b/lib/features/cards/presentation/pages/card_instances_page.dart
@@ -1,4 +1,8 @@
-﻿import 'package:cardpro/features/cards/domain/entities/card_with_instance.dart';
+import 'package:cardpro/core/di/injection_container.dart';
+import 'package:cardpro/db/database.dart' as db;
+import 'package:cardpro/features/cards/domain/entities/card_instance.dart';
+import 'package:cardpro/features/cards/domain/entities/card_instance_location.dart';
+import 'package:cardpro/features/cards/domain/entities/card_with_instance.dart';
 import 'package:cardpro/features/cards/presentation/bloc/card_bloc.dart';
 import 'package:cardpro/features/cards/presentation/bloc/card_event.dart';
 import 'package:cardpro/features/cards/presentation/widgets/card_list_item.dart';
@@ -79,6 +83,7 @@ class _CardInstancesPageState extends State<CardInstancesPage> {
                 // Hide card/set names in grouped view
                 showCardName: false,
                 showSetName: false,
+                onTap: () => _showInstanceEditDialog(item),
                 onDelete: () => _handleDelete(item),
                 onEdit: (description, {String? rarity, String? setName, int? cardNumber}) {
                   context.read<CardBloc>().add(
@@ -93,6 +98,267 @@ class _CardInstancesPageState extends State<CardInstancesPage> {
         );
       },
     );
+  }
+
+  Future<void> _showInstanceEditDialog(CardWithInstance item) async {
+    final database = sl<db.AppDatabase>();
+    final containers = await (database.select(database.containers)).get();
+
+    if (!mounted) {
+      return;
+    }
+
+    final memoController = TextEditingController(text: item.instance.description ?? '');
+    final currentPlacement = item.placements.isNotEmpty ? item.placements.first : null;
+    final locationController =
+        TextEditingController(text: currentPlacement?.location ?? 'main');
+    int? selectedContainerId = currentPlacement?.containerId;
+    bool isSaving = false;
+    String? errorMessage;
+
+    final result = await showDialog<_InstanceUpdateResult>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: const Text('カードインスタンスを編集'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    TextField(
+                      controller: memoController,
+                      maxLines: 3,
+                      decoration: const InputDecoration(
+                        labelText: 'メモ',
+                        hintText: '任意のメモを入力',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    DropdownButtonFormField<int?>(
+                      value: selectedContainerId,
+                      items: [
+                        const DropdownMenuItem<int?>(
+                          value: null,
+                          child: Text('未割り当て'),
+                        ),
+                        ...containers.map(
+                          (container) => DropdownMenuItem<int?>(
+                            value: container.id,
+                            child: Text(
+                              (container.name != null &&
+                                      container.name!.trim().isNotEmpty)
+                                  ? container.name!.trim()
+                                  : '${container.containerType} #${container.id}',
+                            ),
+                          ),
+                        ),
+                      ],
+                      onChanged: isSaving
+                          ? null
+                          : (value) {
+                              final previousId = selectedContainerId;
+                              setState(() {
+                                selectedContainerId = value;
+                                errorMessage = null;
+                                if (value == null) {
+                                  locationController.text = '';
+                                } else if (value != previousId) {
+                                  if (value == currentPlacement?.containerId) {
+                                    locationController.text =
+                                        currentPlacement?.location ?? 'main';
+                                  } else {
+                                    locationController.text = 'main';
+                                  }
+                                }
+                              });
+                            },
+                      decoration: const InputDecoration(
+                        labelText: 'コンテナ',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    TextField(
+                      controller: locationController,
+                      enabled: !isSaving && selectedContainerId != null,
+                      decoration: const InputDecoration(
+                        labelText: 'ロケーション',
+                        hintText: '例: main, side, Slot A',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    if (errorMessage != null) ...[
+                      const SizedBox(height: 12),
+                      Text(
+                        errorMessage!,
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: isSaving
+                      ? null
+                      : () {
+                          Navigator.of(dialogContext).pop();
+                        },
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: isSaving
+                      ? null
+                      : () async {
+                          final memo = memoController.text;
+                          final selectedId = selectedContainerId;
+                          final originalMemo = item.instance.description ?? '';
+                          final originalLocation = currentPlacement?.location ?? '';
+                          final trimmedLocation = locationController.text.trim();
+
+                          final bool placementChanged =
+                              (selectedId ?? -1) != (currentPlacement?.containerId ?? -1) ||
+                                  (selectedId != null && trimmedLocation != originalLocation);
+
+                          if (!placementChanged && memo == originalMemo) {
+                            Navigator.of(dialogContext).pop();
+                            return;
+                          }
+
+                          db.Container? selectedContainer;
+                          String? location;
+
+                          if (selectedId != null) {
+                            if (trimmedLocation.isEmpty) {
+                              setState(() {
+                                errorMessage = 'ロケーションを入力してください';
+                              });
+                              return;
+                            }
+                            selectedContainer = containers
+                                .firstWhere((element) => element.id == selectedId);
+                            location = trimmedLocation;
+                          }
+
+                          setState(() {
+                            isSaving = true;
+                            errorMessage = null;
+                          });
+
+                          try {
+                            if (placementChanged) {
+                              await _applyContainerChange(
+                                item,
+                                selectedContainer,
+                                location,
+                              );
+                            }
+
+                            if (!mounted) {
+                              return;
+                            }
+
+                            if (memo != originalMemo) {
+                              context.read<CardBloc>().add(
+                                    EditCardEvent(
+                                      instance: item.instance,
+                                      description: memo,
+                                    ),
+                                  );
+                            } else if (placementChanged) {
+                              context.read<CardBloc>().add(GetCardsEvent());
+                            }
+
+                            Navigator.of(dialogContext).pop(
+                              _InstanceUpdateResult(
+                                description: memo,
+                                container: selectedContainer,
+                                location:
+                                    selectedId != null ? (location ?? trimmedLocation) : null,
+                              ),
+                            );
+                          } catch (error) {
+                            setState(() {
+                              errorMessage = '保存に失敗しました: $error';
+                              isSaving = false;
+                            });
+                          }
+                        },
+                  child: const Text('保存'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    memoController.dispose();
+    locationController.dispose();
+
+    if (!mounted || result == null) {
+      return;
+    }
+
+    setState(() {
+      _instances = _instances
+          .map(
+            (entry) => entry.instance.id == item.instance.id
+                ? CardWithInstance(
+                    card: entry.card,
+                    instance: CardInstance(
+                      id: entry.instance.id,
+                      cardId: entry.instance.cardId,
+                      updatedAt: entry.instance.updatedAt,
+                      description: result.description,
+                    ),
+                    placements: result.container == null
+                        ? const []
+                        : [
+                            CardInstanceLocation(
+                              containerId: result.container!.id,
+                              containerName: result.container!.name,
+                              containerDescription:
+                                  result.container!.description,
+                              containerType: result.container!.containerType,
+                              isActive: result.container!.isActive,
+                              location: result.location ?? 'main',
+                            ),
+                          ],
+                  )
+                : entry,
+          )
+          .toList();
+    });
+  }
+
+  Future<void> _applyContainerChange(
+    CardWithInstance item,
+    db.Container? container,
+    String? location,
+  ) async {
+    final database = sl<db.AppDatabase>();
+
+    for (final placement in item.placements) {
+      await database.removeCardFromDeck(
+        containerId: placement.containerId,
+        cardInstanceId: item.instance.id,
+      );
+    }
+
+    if (container != null && location != null) {
+      await database.addCardToDeck(
+        containerId: container.id,
+        cardInstanceId: item.instance.id,
+        location: location,
+      );
+    }
   }
 
   void _handleDelete(CardWithInstance item) {
@@ -119,4 +385,16 @@ class _CardInstancesPageState extends State<CardInstancesPage> {
       );
     });
   }
+}
+
+class _InstanceUpdateResult {
+  final String description;
+  final db.Container? container;
+  final String? location;
+
+  const _InstanceUpdateResult({
+    required this.description,
+    required this.container,
+    required this.location,
+  });
 }


### PR DESCRIPTION
## Summary
- reset the location field and validation when changing container selections in the card instance edit dialog and skip saves when nothing changed
- detect placement updates to call the database only when needed, refresh the card list bloc after container moves, and avoid mutating timestamps while syncing local state

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d49b88c2f08329878cdc6ea2f5e6d8