### PR TITLE
Wrap card instances page updates with bloc listener

### DIFF
--- a/lib/features/cards/presentation/pages/card_instances_page.dart
+++ b/lib/features/cards/presentation/pages/card_instances_page.dart
@@ -40,11 +40,38 @@ class _CardInstancesPageState extends State<CardInstancesPage> {
         ? const Center(child: Text('カードインスタンスはまだありません'))
         : _buildGroupedList();
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
+    return BlocListener<CardBloc, CardState>(
+      listener: (context, state) {
+        if (state is CardLoaded) {
+          final ids = widget.instances.map((it) => it.instance.id).toList();
+          final List<CardWithInstance> reordered = [];
+
+          for (final id in ids) {
+            CardWithInstance? match;
+            for (final card in state.cards) {
+              if (card.instance.id == id) {
+                match = card;
+                break;
+              }
+            }
+            if (match != null) {
+              reordered.add(match);
+            }
+          }
+
+          if (!listEquals(_instances, reordered)) {
+            setState(() {
+              _instances = reordered;
+            });
+          }
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.title),
+        ),
+        body: widgetBody,
       ),
-      body: widgetBody,
     );
   }
 


### PR DESCRIPTION
## Summary
- wrap the card instances page scaffold in a `BlocListener`
- reorder and replace the cached instances from `CardLoaded` state so placement summaries refresh after edits

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5ecc881208329abc8dcf75af21dce